### PR TITLE
Implement DataFrame.items

### DIFF
--- a/arrow/src/main/scala/org/sciscala/simpledf/ArrowDataFrame.scala
+++ b/arrow/src/main/scala/org/sciscala/simpledf/ArrowDataFrame.scala
@@ -71,10 +71,8 @@ object arrow {
       override def columns(df: ArrowDataFrame): Seq[String] = df.columns
 
       override def data(df: ArrowDataFrame): Seq[Column[_]] = {
-        val fvs: java.util.List[FieldVector] = df.data.getFieldVectors
-        val fvSeq: Seq[FieldVector] =
-          fvs.toArray(Array.empty[FieldVector]).toSeq
-        fvSeq.map(_.asScala.toSeq)
+        val fvs: Seq[FieldVector] = df.data.getFieldVectors.asScala.toSeq
+        fvs.map(vector => ArrowUtils.vectorAsSeq(df.shape._1, vector))
       }
 
       def get[A](df: ArrowDataFrame, key: A, default: Option[ArrowDataFrame]): ArrowDataFrame = {
@@ -168,6 +166,11 @@ object arrow {
         val size = df.data.getRowCount
         val d = df.data.slice(size - n, size)
         ArrowDataFrame(d, df.index.takeRight(n))
+      }
+
+      override def items(df: ArrowDataFrame): Array[(String, Column[_])] = {
+        val dataAsColumns: Seq[Column[_]] = DataFrame[ArrowDataFrame].data(df)
+        for ( index <- df.columns.indices.toArray) yield df.columns(index) -> dataAsColumns(index)
       }
   }
 

--- a/arrow/src/main/scala/org/sciscala/simpledf/ArrowUtils.scala
+++ b/arrow/src/main/scala/org/sciscala/simpledf/ArrowUtils.scala
@@ -1,0 +1,46 @@
+package org.sciscala.simpledf
+
+import org.apache.arrow.vector._
+import java.sql.Types._
+
+object ArrowUtils {
+
+  def vectorAsSeq(rowCount: Int, vector: FieldVector) : Seq[_] = {
+    vector match {
+      case v: BitVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: FixedSizeBinaryVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TinyIntVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: UInt1Vector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: UInt2Vector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: UInt4Vector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: UInt8Vector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: SmallIntVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: IntVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: BigIntVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: Float4Vector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: Float8Vector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: DecimalVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: VarCharVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: VarBinaryVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: DurationVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: DateDayVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: DateMilliVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: IntervalDayVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: IntervalYearVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeMicroVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeMilliVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeNanoVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeSecVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeStampMicroTZVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeStampMicroVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeStampMilliTZVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeStampMilliVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeStampNanoTZVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeStampNanoVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeStampSecTZVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeStampSecVector => for (row <- 0 until rowCount) yield v.get(row)
+      case v: TimeStampVector => for (row <- 0 until rowCount) yield v.get(row)
+    }
+  }
+
+}

--- a/arrow/src/test/scala/org/sciscala/simpledf/ArrowDataFrameSpec.scala
+++ b/arrow/src/test/scala/org/sciscala/simpledf/ArrowDataFrameSpec.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable.ListBuffer
 
 import DataFrame.ops._
 import scala.languageFeature.postfixOps
+import org.apache.arrow.vector.ValueVector
 
 class ArrowDataFrameSpec extends AnyFlatSpec with Matchers {
 
@@ -364,5 +365,15 @@ class ArrowDataFrameSpec extends AnyFlatSpec with Matchers {
       .insert[UInt4Vector](df, 1, "poison", poisonVector, false)
       .getOrElse(nullArrowDF)
     newDF.data.getVector("poison") shouldBe poisonVector
+  }
+
+  "items" should "return data in Array[(columnName, series)] format, here series is FieldVector" in {
+    val speedVectorAsSeq = ArrowUtils.vectorAsSeq(df.shape._1,data.getVector("speed"))
+    val staminaVectorAsSeq = ArrowUtils.vectorAsSeq(df.shape._1,data.getVector("stamina"))
+    df.items shouldBe Array("speed" -> speedVectorAsSeq, "stamina" -> staminaVectorAsSeq)
+  }
+
+  "items" should "return empty array for emptyDF" in {
+    nullArrowDF.items shouldBe Array() 
   }
 }

--- a/arrow/src/test/scala/org/sciscala/simpledf/ArrowDataFrameSpec.scala
+++ b/arrow/src/test/scala/org/sciscala/simpledf/ArrowDataFrameSpec.scala
@@ -20,7 +20,6 @@ import scala.collection.mutable.ListBuffer
 
 import DataFrame.ops._
 import scala.languageFeature.postfixOps
-import org.apache.arrow.vector.ValueVector
 
 class ArrowDataFrameSpec extends AnyFlatSpec with Matchers {
 
@@ -367,7 +366,7 @@ class ArrowDataFrameSpec extends AnyFlatSpec with Matchers {
     newDF.data.getVector("poison") shouldBe poisonVector
   }
 
-  "items" should "return data in Array[(columnName, series)] format, here series is FieldVector" in {
+  "items" should "return data in Array[(columnName, Column)] format" in {
     val speedVectorAsSeq = ArrowUtils.vectorAsSeq(df.shape._1,data.getVector("speed"))
     val staminaVectorAsSeq = ArrowUtils.vectorAsSeq(df.shape._1,data.getVector("stamina"))
     df.items shouldBe Array("speed" -> speedVectorAsSeq, "stamina" -> staminaVectorAsSeq)

--- a/core/src/main/scala/org/sciscala/simpledf/DataFrame.scala
+++ b/core/src/main/scala/org/sciscala/simpledf/DataFrame.scala
@@ -44,6 +44,7 @@ final case class InsertError(message: String) extends Error
   def tail(df: DFImpl, n: Int = 5): DFImpl
   def to[A](df: DFImpl)(implicit E: Encoder[DFImpl, A]): Seq[A] =
     E.encode(df)
+  def items(df: DFImpl): Array[(String, Column[_])]
 }
 
 object DataFrame {
@@ -208,6 +209,12 @@ object DataFrame {
           df.index.takeRight(n),
           df.columns.takeRight(n)
         )
+
+      override def items(df: ArraySeqDataFrame): Array[(String, Column[_])] = {
+        for {
+          index <- df.columns.indices.toArray
+        } yield (df.columns(index), df.data(index))
+      }
     }
 
 }

--- a/core/src/test/scala/org/sciscala/simpledf/ArraySeqDataFrameSpec.scala
+++ b/core/src/test/scala/org/sciscala/simpledf/ArraySeqDataFrameSpec.scala
@@ -223,7 +223,7 @@ class ArraySeqDataFrameSpec extends AnyFlatSpec with Matchers {
     DataFrame[ArraySeqDataFrame].get[String](df, "poison", None) shouldBe nullArraySeqDF
   }
 
-  "items" should "return data in Array[(columnName, series)] format, here series is ArraySeq" in {
+  "items" should "return data in Array[(columnName, Column)] format" in {
     df.items shouldBe Array("speed" -> data(0), "stamina" -> data(1))
   }
 

--- a/core/src/test/scala/org/sciscala/simpledf/ArraySeqDataFrameSpec.scala
+++ b/core/src/test/scala/org/sciscala/simpledf/ArraySeqDataFrameSpec.scala
@@ -222,4 +222,12 @@ class ArraySeqDataFrameSpec extends AnyFlatSpec with Matchers {
   "get(unknown)" should "return the default value" in {
     DataFrame[ArraySeqDataFrame].get[String](df, "poison", None) shouldBe nullArraySeqDF
   }
+
+  "items" should "return data in Array[(columnName, series)] format, here series is ArraySeq" in {
+    df.items shouldBe Array("speed" -> data(0), "stamina" -> data(1))
+  }
+
+  "items" should "return empty array for emptyDF" in {
+    nullArraySeqDF.items shouldBe Array()
+  }
 }


### PR DESCRIPTION
Implemented items() method for both arrow and arraySeq dfs.
The  output has type Array[(String, Column[_])]
string part of tuple is the label i.e columnName.
since it is array , it also works with for comprehension .
I chose array because it kinda clicked as in spark , collect() returns array of rows .
tell me if we should change it.